### PR TITLE
Update Footer Links of The Docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,16 +52,16 @@ module.exports = {
           title: "Community",
           items: [
             {
-              label: "Stack Overflow",
-              href: "https://stackoverflow.com/questions/tagged/docusaurus",
+              label: "Facebook",
+              href: "https://www.facebook.com/palisadoesproject",
             },
             {
-              label: "Discord",
-              href: "https://discordapp.com/invite/docusaurus",
+              label: "Slack",
+              href: "https://thepalisadoes-dyb6419.slack.com",
             },
             {
               label: "Twitter",
-              href: "https://twitter.com/docusaurus",
+              href: "https://twitter.com/palisadoesorg",
             },
           ],
         },
@@ -74,7 +74,11 @@ module.exports = {
             },
             {
               label: "GitHub",
-              href: "https://github.com/facebook/docusaurus",
+              href: "https://github.com/palisadoesfoundation",
+            },
+            {
+              label: "Youtube",
+              href: "https://www.youtube.com/c/palisadoesorganization",
             },
           ],
         },


### PR DESCRIPTION
**Description:** This PR fixes #31   
**Changes:** All the links in the footer were pointing to the default ones by Facebook and they have been updated to the Foundation's links