### PR TITLE
[GSOC] Docs :  Adding Step by Step Plugin Example 

### DIFF
--- a/docs/functionalities/implementing-plugins-example.md
+++ b/docs/functionalities/implementing-plugins-example.md
@@ -39,6 +39,8 @@ Now let's see how we can implement a Donation feature as plugin and seeing it in
                 )
 ```
 
+To see the entire file go [here](https://github.com/Palisadoesfoundation/talawa/blob/2a14faa4363ca26426fb2f9a8b39082c08e6597b/lib/views/after_auth_screens/profile/profile_page.dart)
+
 It is a simple list option that says " Donate Us " and upon clicking that you get dialog with text "Help us to develop for you" for doing the payment.
 
 Now let's follow the steps.
@@ -94,6 +96,6 @@ This is how the code will look like
 
 ---
 
-Congrats! yove've successfully converted your feature to a plugin. Now you toggle the install/uninstall from the admin panel to see the plugin UI becoming visible if it's installed for that organization otherwise hidden.
+Congrats! yove've successfully converted your feature to a plugin. Now you can  install/uninstall  `Donation`  plugin fromc the  `Plugin Store`  of the  [Talawa Admin](https://github.com/PalisadoesFoundation/talawa-admin) to see the plugin UI becoming visible if it's installed for that organization otherwise hidden.
 
 For developement puprposes to see the plugin even if it's uninstalled you can set the `serverVisible` property to `true`

--- a/docs/functionalities/implementing-plugins-example.md
+++ b/docs/functionalities/implementing-plugins-example.md
@@ -1,0 +1,99 @@
+---
+id: implementing-plugins-example
+title: Implementing Plugins Example
+---
+
+:::note
+Pre-Requsites :
+
+1. [Plugin Architecture ](./plugin-architecture.md)
+2. [Implementing Plugins](./implementing-plugins.md)
+
+:::
+
+Previously we've seen an technical overview of how we can implement plugins for our features.
+
+Now let's see how we can implement a Donation feature as plugin and seeing it in actions. But before that let's take a look at the donation code.
+
+```js
+            CustomListTile(
+                key: homeModel!.keySPDonateUs,
+                index: 2,
+                type: TileType.option,
+                option: Options(
+                    icon: Icon(
+                    Icons.monetization_on,
+                    color: Theme.of(context)
+                    .colorScheme
+                    .primary,
+                    size: 30,
+                ),
+                title: AppLocalizations.of(context)!
+                .strictTranslate('Donate  Us'),
+                subtitle: AppLocalizations.of(context)!
+                    .strictTranslate(
+                    'Help us to develop for you',
+                    ),
+                ),
+                onTapOption: () => donate(context, model),
+                )
+```
+
+It is a simple list option that says " Donate Us " and upon clicking that you get dialog with text "Help us to develop for you" for doing the payment.
+
+Now let's follow the steps.
+
+## 1. Plugin Registration
+
+- Go to the `Plugin Store` and click on the `Add New` button.
+- Give the name as <strong> `Donation` </strong>
+- You add your information for `Creator Name` and `Description` fields.
+- Your plugin should be at visible the store.
+
+let's wrap our widget with the `TalawaPluginProvider` widget as it comes in the type `B` of plugin
+
+## 2. Plugin Creation
+
+- Wrap the donation code with the `TalawaPluginProvider` widget as a `child` property.
+- Add <strong> `Donation` </strong> to `pluginName` property.
+
+This is how the code will look like
+
+```js
+    TalawaPluginProvider(
+         pluginName: "Donation",
+         visible: true,
+         child: Column(
+            children: [
+            CustomListTile(
+                key: homeModel!.keySPDonateUs,
+                index: 2,
+                type: TileType.option,
+                option: Options(
+                icon: Icon(
+                Icons.monetization_on,
+                color: Theme.of(context)
+                .colorScheme
+                .primary,
+                size: 30,
+            ),
+         title: AppLocalizations.of(context)!
+         .strictTranslate('Donate  Us'),
+         subtitle: AppLocalizations.of(context)!
+         .strictTranslate(
+         'Help us to develop for you',
+                        ),
+                    ),
+         onTapOption: () => donate(context, model),
+               ),
+            ],
+         ),
+    )
+
+```
+
+---
+
+Congrats! yove've successfully converted your feature to a plugin. Now you toggle the install/uninstall from the admin panel to see the plugin UI becoming visible if it's installed for that organization otherwise hidden.
+
+For developement puprposes to see the plugin even if it's uninstalled you can set the `serverVisible` property to `true`

--- a/sidebars.js
+++ b/sidebars.js
@@ -27,6 +27,7 @@ module.exports = {
     "Existing Features": [
       "functionalities/core-functionalities",
       "functionalities/plugin-architecture",
+      "functionalities/implementing-plugins-example"
     ],
     "Desired Features": [
       "features/features-introduction",


### PR DESCRIPTION
### This Pull Request is associated with Google Summer of Code 2022 Project  [link](https://summerofcode.withgoogle.com/programs/2022/projects/zjlx9dIj)

 

**What kind of change does this PR introduce?**
 
Added Documentation for plugin implementation example

**Issue Number:**

Fixes #255 


**Did you add tests for your changes?**
Not needed 

**Snapshots/Videos:**
 
![image](https://user-images.githubusercontent.com/65951872/202842113-97b670d8-57c9-495f-8f64-f2873a4e8e15.png)
![image](https://user-images.githubusercontent.com/65951872/202842120-f853c5f8-1515-48e5-857f-3811abf0e740.png)
![image](https://user-images.githubusercontent.com/65951872/202842133-c4ae167c-835d-432b-b5b8-9cd2a617e2b1.png)
![image](https://user-images.githubusercontent.com/65951872/202842140-aea2a767-872e-49a0-bdbd-a54bec30ac58.png)
![image](https://user-images.githubusercontent.com/65951872/202842262-c48d17a9-4cdd-4687-912a-073044b9cd56.png)


**If relevant, did you update the documentation?**
Yes


**Summary**
## This is part 2 of the issue #255  and this page contains code example of plugin conversion

 
**Does this PR introduce a breaking change?**
No
 
**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/master/CONTRIBUTING.md)?**
Yes
