### PR TITLE
Gsod 2023 ideas added

### DIFF
--- a/docs/internships/gsod/ideas.md
+++ b/docs/internships/gsod/ideas.md
@@ -109,16 +109,16 @@ There are others, but these are the main ones that will guide your contributions
 
 Here are the features we'd like to implement in the coming months.
 
-### Add Base Documentation to **Talawa** Repository
+### Add Base Documentation to **Talawa**, and **Talawa-admin** Repositories
 
 Since the introduction of the CI/CD pipeline for automating documentation, there has not been much activity on the bulk of the older files, leaving most of the codebase lacking in documentation. The goal of this task is to add comments on all of the existing methods, events and namespaces of all the classes within the Talawa repository.
 
-The previous Google Season of Docs (Gsod 2022) covered the rest two repositories: Talawa-admin, and Talawa-API.
+The previous Google Season of Docs (Gsod 2022) covered the repository: Talawa-API.
 
-* **Repo to update:** Talawa
-* **Skills Required:** The ideal candidate should be familiar with Typescript and in particular Node.js. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
+* **Repos to update:** Talawa, Talawa-admin.
+* **Skills Required:** The ideal candidate should be familiar with Typescript and in particular Node.js. They also need to be comfortable with using Git/Github and to update the documentation via pull requests. Additionally, knowledge of TSDocs is also required.
 * **How we measure sucess:** Increased documentation for files which have not been modified for more than 3 months. Additionally, an increase in the percentage of the documentation completed from the documentation coverage script that is used. 
-* **Possible Mentors:** Eva Sharma  
+* **Possible Mentors:** Yet to be decided.
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
 ### Create Video Tutorials for **Talawa**, **Talawa API** and **Talawa-Admin**
@@ -140,7 +140,7 @@ Additional information follows:
 * **Repos to update:** Talawa-API, Talawa, Talawa-Admin
 * **Skills Required:** The ideal candidate should be familiar with Javascript and in particular Node.js and TypeScript. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
 * **How we measure sucess:** The creation of tutorials and how-to guides in different forms. 
-* **Possible Mentors:** Eva Sharma 
+* **Possible Mentors:** Yet to be decided. 
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
 ### Create testing guides for **Talawa**, **Talawa API** and **Talawa-Admin**
@@ -155,7 +155,7 @@ Additional information follows:
 * **Repos to update:** Talawa-API, Talawa, Talawa-Admin
 * **Skills Required:** The ideal candidate should be familiar with Javascript and in particular Node.js and TypeScript. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
 * **How we measure sucess:** The creation of tutorials and hot-to guides in different forms. 
-* **Possible Mentors:** Eva Sharma 
+* **Possible Mentors:** Yet to be decided.
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
 ### Create visualisations for various GraphQL Schema and Queries
@@ -165,6 +165,6 @@ The Talawa API has a number of GraphQL queries which are undocumented and have b
 * **Repos to update:** Talawa-API
 * **Skills Required:** The ideal candidate should be familiar with Node.js; GraphQL is not a strict requirement, but they must be willing to learn. Additionally, they need to be comfortable with using Git/Github. Experience in Illustration or graphic design is a plus.
 * **How we measure sucess:** Visualisations present through the base documentation and any new documentation generated from this program.
-* **Possible Mentors:** Eva Sharma 
+* **Possible Mentors:** Yet to be decided. 
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 

--- a/docs/internships/gsod/ideas.md
+++ b/docs/internships/gsod/ideas.md
@@ -84,6 +84,8 @@ Additional information
 
 * The Palisadoes Foundation was selected for Google Summer of Code (GSoC) 2022, and was previously selected for GSoC in 2021. We were able to make a number of leaps and bounds during the 2021 editions which resulted in a massive codebase that is severely undocumented. During this time, the Palisadoes Foundation was also selected for the [Github externship](https://externship.github.in/) on three separate occasions.
 
+* The foundation was also selected for Google Season of Docs (Gsod) 2022. In this season, the documentation status of the repositories was improved. But, some aspects were not covered in this duration and still need to be worked upon.
+
 
 ### General Considerations
 
@@ -107,32 +109,53 @@ There are others, but these are the main ones that will guide your contributions
 
 Here are the features we'd like to implement in the coming months.
 
-### Add Base Documentation for each Repository (Talawa, Talawa-API and Talawa-Admin)
+### Add Base Documentation to **Talawa** Repository
 
-Since the introduction of the CI/CD pipeline for automating documentation, there has not been much activity on the bulk of the older files, leaving most of the three codebases lacking in documentation. The goal of this task is to add comments on all of the existing methods, events and namespaces of all the classes within the Talawa, Talawa-Admin and Talawa API.
+Since the introduction of the CI/CD pipeline for automating documentation, there has not been much activity on the bulk of the older files, leaving most of the codebase lacking in documentation. The goal of this task is to add comments on all of the existing methods, events and namespaces of all the classes within the Talawa repository.
 
-* **Repos to update:** Talawa-API, Talawa, Talawa-Admin
-* **Skills Required:** The ideal candidate should be familiar with Javascript and in particular Node.js. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
+The previous Google Season of Docs (Gsod 2022) covered the rest two repositories: Talawa-admin, and Talawa-API.
+
+* **Repo to update:** Talawa
+* **Skills Required:** The ideal candidate should be familiar with Typescript and in particular Node.js. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
 * **How we measure sucess:** Increased documentation for files which have not been modified for more than 3 months. Additionally, an increase in the percentage of the documentation completed from the documentation coverage script that is used. 
-* **Possible Mentors:** Shannika Jackson, Dominic Mills, Michael Lue, Tasneem Koushar  
+* **Possible Mentors:** Eva Sharma  
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
-### Create How-To Guides and Tutorials for getting started with Talawa, Talawa API and Talawa-Admin
+### Create Video Tutorials for **Talawa**, **Talawa API** and **Talawa-Admin**
 
-Currently, there exists no truly detailed guide on how to get setup and become productive within the basic ecosystems of Talawa, Talawa-API and Talawa-Admin. There are a number of resources available, such as videos demonstrating features from merged pull requests in the respective repositories as well as notes that need to be structured and organised in a meaningful way for a prospective user to be productive with the codebase.
+Currently, there exists no visual guide on how to get started and become productive within the basic ecosystems of Talawa, Talawa-API and Talawa-Admin. 
+In the Gsod 2022, we covered *How-To Guides*  for the three repositories in text formats.
+
+This year, we aim further, with **video tutorials**.
 
 Ideally, we aim to have the following accomplished (though this list is not exhaustive):
 
-1. Improve documentation readability by ensuring the language is accessible by individuals regardless of their language background. This can consist of separating it into two distinct levels, namely: beginners and advanced.
-1. Construct a guide and style format for new technical writers/contributors, to keep the documentation organic with the codebase, up to date and adhering to our standards.
-1. Teaching beginners how to document code optimally and effectively with best practices. In addition to this, include detailed videos and tutorials on using the application, connecting to the API, etc.
+1. Create video tutorials to make the user experience easier and further enhance the user understanding about the three repositories. The guides should be accessible to the individuals despite of their technical backgrounds. This can consist of separating it into two distinct levels, namely: beginners and advanced.
+2. Construct visual guides and style formats for new technical writers/contributors, to keep the documentation organic with the codebase, up to date and adhering to our standards. 
+3.  Instruct beginners on how to document code optimally and effectively with best practices. In addition to this, include detailed videos and tutorials on using the application, connecting to the API, etc.
+
 
 Additional information follows:
 
 * **Repos to update:** Talawa-API, Talawa, Talawa-Admin
 * **Skills Required:** The ideal candidate should be familiar with Javascript and in particular Node.js and TypeScript. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
-* **How we measure sucess:** The creation of tutorials and hot-to guides in different forms (static HTML pages, pdfs, etc). 
-* **Possible Mentors:** Shannika Jackson, Dominic Mills, Michael Lue, Tasneem Koushar 
+* **How we measure sucess:** The creation of tutorials and how-to guides in different forms. 
+* **Possible Mentors:** Eva Sharma 
+* **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
+
+### Create testing guides for **Talawa**, **Talawa API** and **Talawa-Admin**
+If a developer writes some new code, or modifies an existing code, he might have to test it. Thus, writing tests becomes a part of his job.
+The test percent code coverage requirement will incrementally rise with each pull request. In some cases the developer may have to write a few extra tests for the code he may not have updated.
+
+Currently, there are no guides on how to write test codes.
+Thus, the goal of this task is to create proper *How-to guides* on writing test codes to make the developers' jobs easier.
+
+Additional information follows:
+
+* **Repos to update:** Talawa-API, Talawa, Talawa-Admin
+* **Skills Required:** The ideal candidate should be familiar with Javascript and in particular Node.js and TypeScript. Additionally, they need to be comfortable with using Git/Github and to update the documentation via pull requests.
+* **How we measure sucess:** The creation of tutorials and hot-to guides in different forms. 
+* **Possible Mentors:** Eva Sharma 
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
 ### Create visualisations for various GraphQL Schema and Queries
@@ -142,15 +165,6 @@ The Talawa API has a number of GraphQL queries which are undocumented and have b
 * **Repos to update:** Talawa-API
 * **Skills Required:** The ideal candidate should be familiar with Node.js; GraphQL is not a strict requirement, but they must be willing to learn. Additionally, they need to be comfortable with using Git/Github. Experience in Illustration or graphic design is a plus.
 * **How we measure sucess:** Visualisations present through the base documentation and any new documentation generated from this program.
-* **Possible Mentors:** Shannika Jackson, Dominic Mills, Michael Lue, Tasneem Koushar 
+* **Possible Mentors:** Eva Sharma 
 * **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)
 
-### Revamp and Restructure the Current Documentation Page
-
-The website that currently hosts the documentation is rather simplistic and has not evolved from when the Talawa application was more refined than it is now. It no longer takes into consideration the needs of contributing to a complex, multi-layered application, and as such it needs to be remodelled and redesigned to account for a number of changes that have and are currently taking place. Remodelling involves re-writing much of the documentation already in place on the site, as well as, working with a candidate that may be adding to the documentation and ensuring that templates are in place such that the look and feel of the site is cogent and consistent. Note: it is possible to work on this task in conjunction with another one of the aforementioned tasks here..
-
-* **Repos to update:** Talawa-API
-* **Skills Required:** HTML, Javascript, CSS. Any design skills would be a plus. Must also be comfortable using Github to submit changes.
-* **How we measure sucess:** A website structured in a completely different manner, which is more efficient and effective in providing the information for a user wishing contribute to Talawa. This can be measured by the increase in new contributors via pull requests.
-* **Possible Mentors:** Shannika Jackson, Dominic Mills, Michael Lue, Tasneem Koushar 
-* **Contact details:** Send your CV along with at least two technical writing samples to ![img](/img/email/mentors.png)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Added new ideas for GSOD 2023 to the `docs/internships/gsod/ideas.md` page.

**Issue Number:**

#286 


**Summary**

- I removed the previous (Gsod 2022) ideas which got implemented last year.
- Added new ideas for Gsod 2023.
- Reviewed `docs/internships/ideas.md` page for any possible Gsod ideas.
- Kept one idea from Gsod 2022 which wasn't implemented last year.


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**

Yes
