### PR TITLE
Feat:-Added sidebar hide and show option to the docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,6 +46,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      docs: {
+        sidebar: {
+          hideable: true,
+        },
+      },
       navbar: {
         title: 'Talawa',
         logo: {


### PR DESCRIPTION
Fix #343 

As discussed in the Issue, I added the option to make the sidebar hide and show on the documentation website.

https://user-images.githubusercontent.com/72331432/223469079-54dae975-c578-481b-9be8-3c7f86585d74.mp4

