### PR TITLE
Bug Report:- Subsection of the Documentation uses h3 heading instead …

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -48,7 +48,7 @@ function Feature({title, Svg, description}: FeatureItem) {
         <Svg className={styles.featureSvg} role="img" />
       </div>
       <div className="text--center padding-horiz--md">
-        <h3>{title}</h3>
+        <h2>{title}</h2>
         <p>{description}</p>
       </div>
     </div>


### PR DESCRIPTION
![2023-03-09 (1)](https://user-images.githubusercontent.com/96948435/223927890-7c9a2cb5-65c5-46f4-a539-a813f4916f07.png)
**Before**
![2023-03-09](https://user-images.githubusercontent.com/96948435/223927903-6a43778a-1f8e-48b0-a0e4-1261797e9c51.png)
**After**
**I Try to solve this Issue please review**