### PR TITLE
Fix:-Decreased h1 text font size for small and medium size screen devices

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -223,7 +223,7 @@ h1.docTitle_node_modules-\@docusaurus-theme-classic-src-theme-DocItem- {
         margin-right: 0.5rem;
     }
     .hero__title {
-    font-size: 2rem;
+        font-size: 2rem;
     }
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -212,6 +212,7 @@ h1.docTitle_node_modules-\@docusaurus-theme-classic-src-theme-DocItem- {
     .center {
         text-align: center;
     }
+
 }
 
 @media (max-width: 1000px) {
@@ -220,6 +221,9 @@ h1.docTitle_node_modules-\@docusaurus-theme-classic-src-theme-DocItem- {
     }
     .github-button {
         margin-right: 0.5rem;
+    }
+    .hero__title {
+    font-size: 2rem;
     }
 }
 


### PR DESCRIPTION
 <!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Changed the heading font size for smaller and medium size screen, this way the text does not currently break for mobile screen

**Issue Number:**

Fixes #409 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![Talawa Project Documentation _ Talawa Project Documentation — Mozilla Firefox 3_9_2023 10_26_39 PM](https://user-images.githubusercontent.com/72331432/224237241-74045c64-88c7-49c4-a225-09cfbabe8c44.png)


**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
Changed the `custom.css` file and added the rule for `hero__title` to be 2rem , which seems perfect for smaller and medium size screens

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**

yes