### PR TITLE
fixed extra spacing between elements

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -131,14 +131,14 @@ h1.docTitle_node_modules-\@docusaurus-theme-classic-src-theme-DocItem- {
 
 .markdown>h2 {
     --ifm-h2-font-size: 1.875rem;
-    margin-bottom: 1.5rem;
-    margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * 1rem);
+    margin-bottom: 0.8rem;
+    margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * 0rem);
 }
 
 .markdown>h3 {
     --ifm-h3-font-size: 1.5rem;
-    margin-bottom: 1rem;
-    margin-top: calc(var(--ifm-h3-vertical-rhythm-top) * 1rem);
+    margin-bottom: 0.8rem;
+    margin-top: calc(var(--ifm-h3-vertical-rhythm-top) * 0rem);
 }
 
 .navbar__items--right>.navbar__item:not(:first-of-type) {


### PR DESCRIPTION
 <!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**Check PR #466 for context**
(yarn.lock fixed in context of the comment by @palisadoes:

1. This is a CSS change. Yarn.lock is not required. Please remove it from the PR.
2. Also, update to the latest version of docusaurus, that's probably why there is a variance in yarn.lock)

**Issue Number:**
Fixes #456

**Explanation**
Could not merge the changes into PR #466, that's why had to create New PR.