### PR TITLE
Changed the h3 title to normal text in the Talawa API overview page

### DIFF
--- a/docs/developers/talawa-api/api-overview.md
+++ b/docs/developers/talawa-api/api-overview.md
@@ -3,7 +3,7 @@ id: api-overview
 title: Overview
 ---
 
-> ### Talawa Api is the backend for the application talawa written in `typescript`. It is the base of all the functionalities offered to Users and Organizations that sign up at talawa. In upcoming sections you will get to know all the useful functions performed by the Api. _Stay tuned!_
+>  Talawa Api is the backend for the application talawa written in `typescript`. It is the base of all the functionalities offered to Users and Organizations that sign up at talawa. In upcoming sections you will get to know all the useful functions performed by the Api. _Stay tuned!_
 
 <b></b>
 

--- a/docs/functionalities/core-functionalities.md
+++ b/docs/functionalities/core-functionalities.md
@@ -4,8 +4,9 @@ title: Core Functionalities
 ---
 
 
-> ### The current Talawa app is functional but does not meet many best practices. We need to refactor the code to be internationally acceptable. 
-> ### Before we can add any new functionality. The refactored app needs to meet these basic requirements on which the original application was based.
+>The current Talawa app is functional but does not meet many best practices. We need to refactor the code to be internationally acceptable. 
+
+> Before we can add any new functionality. The refactored app needs to meet these basic requirements on which the original application was based.
 
 ## User Registration
 ### Description

--- a/docs/internships/outreachy/introduction.md
+++ b/docs/internships/outreachy/introduction.md
@@ -20,7 +20,7 @@ Find out more about the [eligibility](https://www.outreachy.org/docs/applicant/)
 
 ### Some Useful Links
 
-here are some links to get you started 
+Here are some links to get you started 
 1. [Eligibility Criteria](https://www.outreachy.org/docs/applicant/#eligibility)
 1. [Applying for Outreachy Internship](https://www.outreachy.org/apply/)
 1. [Internship Guide](https://www.outreachy.org/docs/internship/)


### PR DESCRIPTION
 <!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**I changed the h3 titles in the Talawa API overview page and the Requirement Docs core functionalities page to normal text
since they were big and therefore not uniform with the rest of the page's contents.**
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #471

