### PR TITLE
Navbar opens linkes in new tab, and footer updated

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,13 +65,13 @@ const config = {
                 },
                 {
                     href: 'https://docs.talawa.io/talawa/index.html',
-                    target: "_self",
+                    target: "_blank",
                     label: "Talawa",
                     position: "left",
                 },
                 {
                     href: 'https://docs.talawa.io/talawa-api/schema/index.html',
-                    target: "_self",
+                    target: "_blank",
                     label: "Talawa Api",
                     position: "left",
                 },
@@ -142,7 +142,7 @@ const config = {
                     ],
                 },
             ],
-            copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
+            copyright: `Copyright © ${new Date().getFullYear()} Talawa, Inc. Built with Docusaurus.`,
         },
         prism: {
             theme: lightCodeTheme,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,19 +64,19 @@ const config = {
                     position: "left",
                 },
                 {
-                    href: 'https://docs.talawa.io/talawa/index.html',
+                    to: 'https://docs.talawa.io/talawa/index.html',
                     target: "_blank",
                     label: "Talawa",
                     position: "left",
                 },
                 {
-                    href: 'https://docs.talawa.io/talawa-api/schema/index.html',
+                    to: 'https://docs.talawa.io/talawa-api/schema/index.html',
                     target: "_blank",
                     label: "Talawa Api",
                     position: "left",
                 },
                 {
-                    href: 'https://github.com/PalisadoesFoundation',
+                    to: 'https://github.com/PalisadoesFoundation',
                     label: 'GitHub',
                     position: 'right',
                 },


### PR DESCRIPTION
 <!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
The Talawa and Talawa Api headings in the Navbar now open in a new tab.
The footer needs to be updated and "My Project" is changed to "Talawa"

**Issue Number:**

Fixes #507 

**Snapshots/Videos:**
The links open up in a new tab.
![image](https://user-images.githubusercontent.com/97171261/225637509-914f128d-0555-43f1-bc39-653de70ea21a.png)

Footer is updated
![image](https://user-images.githubusercontent.com/97171261/225637649-acd1d0d7-918e-469a-8f39-57eca1087a2e.png)

**Summary**
In general, opening different UIs or pages in a new tab can be helpful for users to navigate between them without losing their current context. This is especially true when the user is interacting with multiple pages or services at the same time. Opening new tabs also helps to avoid confusion and improves the user experience. Thus with this bug fix, we have enabled that.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**
Yes
