### PR TITLE
Fix page break and header text

### DIFF
--- a/docs/functionalities/plugin-architecture.md
+++ b/docs/functionalities/plugin-architecture.md
@@ -66,4 +66,4 @@ Admin portal and talwa app must be of same organizations
 
 :::
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lrf9LApT37U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/lrf9LApT37U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -130,13 +130,13 @@ h1.docTitle_node_modules-\@docusaurus-theme-classic-src-theme-DocItem- {
 }
 
 .markdown>h2 {
-    --ifm-h2-font-size: 1.875rem;
+    --ifm-h2-font-size: 1.3rem;
     margin-bottom: 0.8rem;
     margin-top: calc(var(--ifm-h2-vertical-rhythm-top) * 0rem);
 }
 
 .markdown>h3 {
-    --ifm-h3-font-size: 1.5rem;
+    --ifm-h3-font-size: 1.1rem;
     margin-bottom: 0.8rem;
     margin-top: calc(var(--ifm-h3-vertical-rhythm-top) * 0rem);
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix

**Issue Number:**

Fixes issue #485 

**Snapshots/Videos:**

Before | After
------------- | -------------
![image](https://user-images.githubusercontent.com/74814780/225734587-1ec43947-de2b-452b-b0da-e28233dad2f1.png)  |  ![image](https://user-images.githubusercontent.com/74814780/225734475-cb0cb056-4b01-4eda-bb25-b30ea2936e72.png)


**Summary**

- In this PR I fixed the page break in the "plugin-architecture" page.
- I also adjusted the `font-size` of the `h2` and `h3` tags because of how similar they looked so as to make a clear hierarchy of different headers to make it easier for users to differentiate different headings.

**Does this PR introduce a breaking change?**

No

**Other information**

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**

<!--Yes or No-->
