### PR TITLE
removed extra margin-bottom in section six

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -978,7 +978,10 @@
    padding-top: 30px; 
    left: 300px;
 }
-
+/* Correction for the bottom space in section six*/
+#docusaurus_skipToContent_fallback > section.Section.SixthPanel.tint > div > div.column.last.right > div{
+    margin-bottom: 0;
+}
 
 /* Native Code */
 
@@ -990,7 +993,7 @@
 }
 
 .SixthPanel .column.last {
-  margin-bottom: -30px;
+  margin-bottom: -49px;
 }
 
 .SixthPanel pre {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -332,7 +332,7 @@ function CrossPlatform() {
 
 function SixthPanel() {
   return (
-    <Section className="SixthPanel" background='tint'>
+    <Section className="SixthPanel" background='tint' >
       <TwoColumns
         columnOne={
           <TextColumn


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Refactoring Section six of the talawa home page because it had extra margin

**Issue Number:**#618

Fixes ##618

**Did you add tests for your changes?**
no text are not required

**Snapshots/Videos:**
**Before**

![Talawa docs](https://user-images.githubusercontent.com/58564800/229536974-c85f8cbc-573e-400f-ace0-96b651e93be2.png)

**After**

![Annotation 2023-04-03 151528](https://user-images.githubusercontent.com/58564800/229540117-b01c3f4f-1fd3-488e-8d3f-50db808512d6.png)





**If relevant, did you update the documentation?**
I refactored the code section to have the correct margin
https://docs.talawa.io/

**Summary**

On Talawa docs home page the section with the code was having extra bottom margin which did not make it appealing to look at and switching to responsive mode would contain the embedded code in extra margin
#618 

**Does this PR introduce a breaking change?**

It does not

**Other information**



**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**

Yes
