### PR TITLE
feat: added responsiveness for tablets and learn more button

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -502,6 +502,7 @@
 .ActionButton.primary {
   color: var(--dark);
   background-color: #FEBC59;
+  text-wrap: nowrap;
 }
 
 .ActionButton.primary:hover {
@@ -525,6 +526,27 @@
 }
 
 @media only screen and (max-width: 480px) {
+  .ActionButton {
+    max-width: 100%;
+    width: 100%;
+    display: block;
+    white-space: nowrap;
+  }
+
+  .ActionButton.secondary {
+    margin-top: 1rem;
+    margin-left: auto;
+  }
+
+  .custom-image {
+    width: 80%;
+  }
+
+}
+
+/* responsiveness for tablets */
+
+@media only screen and (min-width: 481px) and (max-width: 960px) {
   .ActionButton {
     max-width: 100%;
     width: 100%;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds responsiveness for tablets and fixes the collapsing learn more button on the hero section

**Issue Number:**

Fixes #889 

**Snapshots/Videos:**
https://www.loom.com/share/0dd44490829d4a12961143448539a505


**Summary**

While I was going through the [docs](https://docs.talawa.io/) in my tab, I felt that the user experience can be better if responsiveness for tablet screens are added. Also noticed the "learn more" button collapsing for wider screens. This pull request fixes the issue.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-docs/blob/develop/CONTRIBUTING.md)?**

yes